### PR TITLE
Switch ssh to https for tk-unreal and tk-framework-unrealqt

### DIFF
--- a/env/includes/engine_locations.yml
+++ b/env/includes/engine_locations.yml
@@ -81,8 +81,7 @@ engines.tk-shotgun.location:
 
 # Unreal
 engines.tk-unreal.location:
-  type: git_branch
-  path: git@github.com:shotgunsoftware/tk-unreal
-  branch: master
+  type: git
+  path: https://github.com/shotgunsoftware/tk-unreal
   version: e589cdfe37b7eee89328920c26f913617d4ef5a3
 

--- a/env/includes/frameworks.yml
+++ b/env/includes/frameworks.yml
@@ -58,7 +58,6 @@ frameworks:
   # unrealqt - PySide build for Unreal (Windows-only)
   tk-framework-unrealqt_v1.x.x:
     location:
-      type: git_branch
-      path: git@github.com:shotgunsoftware/tk-framework-unrealqt
-      branch: master
+      type: git
+      path: https://github.com/shotgunsoftware/tk-framework-unrealqt
       version: d21ff6124a901ce018ab639cbefe8bfc67115a79


### PR DESCRIPTION
Sometimes sg desktop gets stuck when the github host ip is not in ~/.ssh/known_hosts.
Since it is a public repo, switch to https would solve the problem.