### PR TITLE
engine and framework https locations

### DIFF
--- a/env/includes/engine_locations.yml
+++ b/env/includes/engine_locations.yml
@@ -82,7 +82,7 @@ engines.tk-shotgun.location:
 # Unreal
 engines.tk-unreal.location:
   type: git_branch
-  path: git@github.com:shotgunsoftware/tk-unreal
+  path: https://github.com/shotgunsoftware/tk-unreal.git
   branch: master
   version: e589cdfe37b7eee89328920c26f913617d4ef5a3
 

--- a/env/includes/frameworks.yml
+++ b/env/includes/frameworks.yml
@@ -59,6 +59,6 @@ frameworks:
   tk-framework-unrealqt_v1.x.x:
     location:
       type: git_branch
-      path: git@github.com:shotgunsoftware/tk-framework-unrealqt
+      path: https://github.com/shotgunsoftware/tk-framework-unrealqt.git
       branch: master
       version: d21ff6124a901ce018ab639cbefe8bfc67115a79


### PR DESCRIPTION
I've updated the config to use https git locations to remove the requirement for ssh keys.

Having a location using a path like this: `git@github.com:shotgunsoftware/tk-unreal`
meant that when setting up the config in the Shotgun Desktop advanced setup wizard, it would error if the user did not have an ssh key configured for git and Github. 

Using the https URL means there is no longer a requirement for them to setup ssh.
Cheers
Phil